### PR TITLE
correct icons to match with the icons used in the Gameloft releases of CTR Experiments (v1.9.4) and CTR2 (v1.22.0)

### DIFF
--- a/games/cut-the-rope-2/index.html
+++ b/games/cut-the-rope-2/index.html
@@ -36,7 +36,7 @@
                     <a href="https://github.com/TheAwesomeBlue/ctrfiles/releases/download/Stuff/Cut.the.Rope.2.v1.15.1.Gameloft.apk" class="recommended"><p>Cut the Rope 2 v1.15.1 Gameloft ⭐</p></a>
                 </div>
                 <div class="platformdownload">
-                    <img src="/img/icons/ctr2/ctr2.png" class="platformicon">
+                    <img src="/img/icons/ctr2/ctr2_android.png" class="platformicon">
                     <div class="downloaddiv">
                 <img src="/img/icons/platforms/android.png" class="platformextra">
                 </div>

--- a/games/cut-the-rope-experiments/index.html
+++ b/games/cut-the-rope-experiments/index.html
@@ -52,7 +52,7 @@
                 <a href="https://theawesomeblue.github.io/ctrfiles/download/ctre/Cut-the-Rope-Experiments-v1-11-0.apk"><p>Cut the Rope Experiments GOLD 1.11.0 (Supports ARM64)</p></a>
             </div>
             <div class="platformdownload">
-                <img src="/img/icons/ctrexp/ctrexp_gold.png" class="platformicon">
+                <img src="/img/icons/ctrexp/ctrexp_modern.png" class="platformicon">
                 <div class="downloaddiv">
                 <img src="/img/icons/platforms/android.png" class="platformextra">
                 </div>


### PR DESCRIPTION
CTR Experiments Gameloft v1.9.4 uses the modern icon and CTR2 Gameloft v1.22.0 uses the new modern CTR2 Android icon.